### PR TITLE
The global "this" object should not be used 

### DIFF
--- a/public/javascripts/calc-shipping.js
+++ b/public/javascripts/calc-shipping.js
@@ -62,4 +62,4 @@
   };
 
 }
-(this, this.document));
+(this, document));


### PR DESCRIPTION
Remove the use of "this".

When the keyword this is used outside of an object, it refers to the global this object, which is the same thing as the window object in a standard web page. Such uses could be confusing to maintainers. Instead, simply drop the this, or replace it with window; it will have the same effect and be more readable.

http://sonarqube-sonarqube-tools.devops-gse-state-458654-0143c5dd31acd8e030a1d6e0ab1380e3-0001.us-east.containers.appdomain.cloud/project/issues?id=bluecompute-web&open=AXDvP0HcmY_dhoPXmnof&resolved=false&types=CODE_SMELL